### PR TITLE
Use same flags for sync and view

### DIFF
--- a/internal/commands/transactions/transactions.go
+++ b/internal/commands/transactions/transactions.go
@@ -112,13 +112,20 @@ func createViewCommand(props *props.AppProps) *cli.Command {
 
 func createSyncCommand(props *props.AppProps) *cli.Command {
 	return &cli.Command{
-		Name:      "sync",
-		Usage:     "Sync transactions for a given principal",
-		ArgsUsage: "principal",
+		Name:  "sync",
+		Usage: "Sync transactions for a given principal",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "principal",
+				Aliases:  []string{"p"},
+				Usage:    "Specify the principal",
+				Required: true,
+			},
+		},
 		Action: func(c *cli.Context) error {
-			principal := c.Args().First()
+			principal := c.String("principal")
 			if principal == "" {
-				return cli.NewExitError("Please provide a principal (address or contract identifier)", 1)
+				return cli.Exit("Please provide a principal (address or contract identifier)", 1)
 			}
 			return syncTransactions(props, principal)
 		},

--- a/internal/commands/transactions/transactions.go
+++ b/internal/commands/transactions/transactions.go
@@ -124,9 +124,6 @@ func createSyncCommand(props *props.AppProps) *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			principal := c.String("principal")
-			if principal == "" {
-				return cli.Exit("Please provide a principal (address or contract identifier)", 1)
-			}
 			return syncTransactions(props, principal)
 		},
 	}

--- a/pkg/api/hiro/structs.go
+++ b/pkg/api/hiro/structs.go
@@ -27,6 +27,20 @@ type TokenTransfer struct {
 	Memo             string `json:"memo,omitempty"`
 }
 
+type ContractCall struct {
+	ContractId        string         `json:"contract_id,omitempty"`
+	FunctionName      string         `json:"function_name,omitempty"`
+	FunctionSignature string         `json:"function_signature,omitempty"`
+	FunctionArgs      []ClarityValue `json:"function_args,omitempty"`
+}
+
+type ClarityValue struct {
+	Hex  string `json:"hex,omitempty"`
+	Repr string `json:"repr,omitempty"`
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
 type Tx struct {
 	TxID                     string        `json:"tx_id,omitempty"`
 	Nonce                    int           `json:"nonce,omitempty"`
@@ -47,6 +61,7 @@ type Tx struct {
 	ParentBurnBlockTime      int           `json:"parent_burn_block_time,omitempty"`
 	ParentBurnBlockTimeIso   time.Time     `json:"parent_burn_block_time_iso,omitempty"`
 	Canonical                bool          `json:"canonical,omitempty"`
+	ContractCall             ContractCall  `json:"contract_call,omitempty"`
 	TxIndex                  int           `json:"tx_index,omitempty"`
 	TxStatus                 string        `json:"tx_status,omitempty"`
 	TxResult                 TxResult      `json:"tx_result,omitempty"`
@@ -54,7 +69,7 @@ type Tx struct {
 	MicroblockSequence       int64         `json:"microblock_sequence,omitempty"`
 	MicroblockCanonical      bool          `json:"microblock_canonical,omitempty"`
 	EventCount               int           `json:"event_count,omitempty"`
-	Events                   []any         `json:"events,omitempty"`
+	Events                   []Event       `json:"events,omitempty"`
 	ExecutionCostReadCount   int           `json:"execution_cost_read_count,omitempty"`
 	ExecutionCostReadLength  int           `json:"execution_cost_read_length,omitempty"`
 	ExecutionCostRuntime     int           `json:"execution_cost_runtime,omitempty"`
@@ -86,6 +101,29 @@ type Events struct {
 	Stx Stx `json:"stx,omitempty"`
 	Ft  Ft  `json:"ft,omitempty"`
 	Nft Nft `json:"nft,omitempty"`
+}
+
+type Event struct {
+	EventIndex  int         `json:"event_index,omitempty"`
+	EventType   string      `json:"event_type,omitempty"`
+	TxId        string      `json:"tx_id,omitempty"`
+	Asset       Asset       `json:"asset,omitempty"`
+	ContractLog ContractLog `json:"contract_log,omitempty"`
+}
+
+type Asset struct {
+	AssetEventType string       `json:"asset_event_type,omitempty"`
+	Sender         string       `json:"sender,omitempty"`
+	Recipient      string       `json:"recipient,omitempty"`
+	Amount         int          `json:"amount,omitempty"`
+	AssetId        string       `json:"asset_id,omitempty"`
+	Value          ClarityValue `json:"value,omitempty"`
+}
+
+type ContractLog struct {
+	ContractId string       `json:"contract_id,omitempty"`
+	Topic      string       `json:"topic,omitempty"`
+	Value      ClarityValue `json:"value,omitempty"`
 }
 
 type TokenResult struct {


### PR DESCRIPTION
### **User description**
This PR
* changes `teller transactions sync SP1234` to `teller transactions sync -p SP1234`
* adds more structs in Hiro for better transaction sync 

___

### **PR Type**
enhancement


___

### **Description**
- Refactored the `createSyncCommand` in `transactions.go` to enhance command line usability:
  - Introduced flag-based input for specifying the principal, aligning it with other commands.
  - The principal parameter is now mandatory, improving error handling and user feedback.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transactions.go</strong><dd><code>Refactor Sync Command to Use Flags for Input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
internal/commands/transactions/transactions.go

<li>Modified the <code>createSyncCommand</code> function to use flag-based input for <br>the principal parameter.<br> <li> Added a <code>StringFlag</code> for the principal with an alias 'p', making it <br>required.<br> <li> Changed the retrieval of the principal parameter to use <br><code>c.String("principal")</code> instead of <code>c.Args().First()</code>.<br> <li> Updated the error handling to use <code>cli.Exit</code> instead of <br><code>cli.NewExitError</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/hashhavoc/teller/pull/33/files#diff-fa118ee8f2117e3d91dba5adea8a87f64944f4c137f0bafb44bf60f0e2d18faa">+12/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

